### PR TITLE
fix: missing tables and columns in shemas.sql file

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -29,6 +29,8 @@ CREATE TABLE IF NOT EXISTS `players` (
   `looktype` int NOT NULL DEFAULT '136',
   `lookaddons` int NOT NULL DEFAULT '0',
   `direction` tinyint unsigned NOT NULL DEFAULT '2',
+  `currentmount` smallint unsigned NOT NULL DEFAULT '0',
+  `randomizemount` tinyint NOT NULL DEFAULT '0',
   `maglevel` int NOT NULL DEFAULT '0',
   `mana` int NOT NULL DEFAULT '0',
   `manamax` int NOT NULL DEFAULT '0',
@@ -348,6 +350,13 @@ CREATE TABLE IF NOT EXISTS `player_outfits` (
   `outfit_id` smallint unsigned NOT NULL DEFAULT '0',
   `addons` tinyint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`player_id`,`outfit_id`),
+  FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+
+CREATE TABLE IF NOT EXISTS `player_mounts` (
+  `player_id` int NOT NULL DEFAULT '0',
+  `mount_id` smallint unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`player_id`,`mount_id`),
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 


### PR DESCRIPTION
fix at login: 

- Table 'XXXXXXXXX.player_mounts' doesn't exist
- Message: Unknown column 'currentmount' in 'field list
- Message: Unknown column 'randomizemount' in 'field list'

```
[Error - mysql_real_query] Query: DELETE FROM `player_mounts` WHERE `player_id` = 1
Message: Table '860new.player_mounts' doesn't exist
```

```
[Error - mysql_store_result] Query: SELECT `id`, `name`, `account_id`, `group_id`, `sex`, `vocation`, `experience`, `level`, `maglevel`, `health`, `healthmax`, `blessings`, `mana`, `manamax`, `manaspent`, `soul`, `lookbody`, `lookfeet`, `lookhead`, `looklegs`, `looktype`, `lookaddons`, `currentmount`, `randomizemount`, `posx`, `posy`, `posz`, `cap`, `lastlogin`, `lastlogout`, `lastip`, `conditions`, `skulltime`, `skull`, `town_id`, `balance`, `stamina`, `skill_fist`, `skill_fist_tries`, `skill_club`, `skill_club_tries`, `skill_sword`, `skill_sword_tries`, `skill_axe`, `skill_axe_tries`, `skill_dist`, `skill_dist_tries`, `skill_shielding`, `skill_shielding_tries`, `skill_fishing`, `skill_fishing_tries`, `direction` FROM `players` WHERE `id` = 1
Message: Unknown column 'randomizemount' in 'field list'
```
`Message: Unknown column 'currentmount' in 'field list'`

