### PR TITLE
fix Visual Studio and CMake builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build/
 [Bb]in/
 [Oo]bj/
 cmake-build-*/
+/vcpkg_installed
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,13 @@
-FROM alpine:3.17.3 AS build
-# crypto++-dev is in edge/community
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
-  build-base \
-  boost-dev \
-  cmake \
-  crypto++-dev \
-  fmt-dev \
-  lua \
-  mariadb-connector-c-dev \
-  pugixml-dev \
-  samurai
+FROM ubuntu:22.04
 
-COPY cmake /usr/src/forgottenserver-downgrade/cmake/
-COPY src /usr/src/forgottenserver-downgrade/src/
-COPY CMakeLists.txt CMakePresets.json /usr/src/forgottenserver-downgrade/
-WORKDIR /usr/src/forgottenserver-downgrade
+RUN apt update && \
+    apt install -yq cmake build-essential ninja-build \
+    libcrypto++-dev libfmt-dev liblua5.4-dev libmysqlclient-dev \
+    libboost-iostreams-dev libboost-locale-dev libboost-system-dev libpugixml-dev
+
+COPY cmake /usr/src/forgottenserver/cmake/
+COPY src /usr/src/forgottenserver/src/
+COPY CMakeLists.txt CMakePresets.json /usr/src/forgottenserver/
+WORKDIR /usr/src/forgottenserver
+
 RUN cmake --preset default && cmake --build --config RelWithDebInfo --preset default
-
-FROM alpine:3.17.3
-# crypto++ is in edge/community
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
-  boost-iostreams \
-  boost-system \
-  crypto++ \
-  fmt \
-  lua \
-  mariadb-connector-c \
-  pugixml
-
-COPY --from=build /usr/src/forgottenserver-downgrade/build/tfs /bin/tfs
-COPY data /srv/data/
-COPY LICENSE README.md *.dist *.sql key.pem /srv/
-
-EXPOSE 7171 7172
-WORKDIR /srv
-VOLUME /srv
-ENTRYPOINT ["/bin/tfs"]

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -307,7 +307,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	if (currExpCount < nextExpCount) {
 		player->levelPercent = static_cast<uint8_t>(
-		    Player::getBasisPointLevel(player->experience - currExpCount, nextExpCount - currExpCount) / 100);
+		    Player::getBasisPointLevel(player->experience - currExpCount, nextExpCount - currExpCount));
 	} else {
 		player->levelPercent = 0;
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1622,7 +1622,7 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText /* = fa
 	}
 
 	if (nextLevelExp > currLevelExp) {
-		levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp) / 100;
+		levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp);
 	} else {
 		levelPercent = 0;
 	}
@@ -1702,7 +1702,7 @@ void Player::removeExperience(uint64_t exp, bool sendText /* = false*/)
 
 	uint64_t nextLevelExp = Player::getExpForLevel(level + 1);
 	if (nextLevelExp > currLevelExp) {
-		levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp) / 100;
+		levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp);
 	} else {
 		levelPercent = 0;
 	}
@@ -1927,7 +1927,7 @@ void Player::death(Creature* lastHitCreature)
 			uint64_t currLevelExp = Player::getExpForLevel(level);
 			uint64_t nextLevelExp = Player::getExpForLevel(level + 1);
 			if (nextLevelExp > currLevelExp) {
-				levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp) / 100;
+				levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp);
 			} else {
 				levelPercent = 0;
 			}

--- a/vc17/theforgottenserver.vcxproj
+++ b/vc17/theforgottenserver.vcxproj
@@ -29,16 +29,19 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
+    <EnableUnitySupport>true</EnableUnitySupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
+    <EnableUnitySupport>true</EnableUnitySupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
+    <EnableUnitySupport>true</EnableUnitySupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -87,6 +90,9 @@
     <TargetName>$(ProjectName)-$(Platform)</TargetName>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>_CONSOLE;$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -95,7 +101,7 @@
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <AdditionalIncludeDirectories>$(VcpkgRoot)include\%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -110,7 +116,7 @@
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <AdditionalIncludeDirectories>$(VcpkgRoot)include\%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -128,7 +134,7 @@
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <AdditionalIncludeDirectories>$(VcpkgRoot)include\luajit;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -149,7 +155,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VcpkgRoot)include\%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,5 +21,5 @@
             ]
         }
     },
-    "builtin-baseline": "7f59e0013648f0dd80377330b770b414032233cb"
+    "builtin-baseline": "215a2535590f1f63788ac9bd2ed58ad15e6afdff"
 }


### PR DESCRIPTION
Visual Studio project and `vcpkg.json` changes to make it compile in VS and CMake on Windows with vcpkg.

After these changes you don't have to run `./vcpkg install xxx` before compilation. Just install newest vcpkg and integrate it with OS.
VS will install all required C++ libraries in `vcpkg_installed` subfolder of OTS when you start compilation.
