### PR TITLE
fix: Opcode in OTCR and OTC edubart

### DIFF
--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -78,7 +78,7 @@ end
 function Player.isUsingOtClient(self) return self:getClient().os >= CLIENTOS_OTCLIENT_LINUX end
 
 function Player.sendExtendedOpcode(self, opcode, buffer)
-	if not self:isUsingOtcV8() then return false end
+	if not self:isUsingOtClient() then return false end
 
 	local networkMessage<close> = NetworkMessage()
 	networkMessage:addByte(0x32)

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -370,7 +370,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		isOTCv8 = msg.get<uint16_t>() != 0;
 	}
 
-	if (operatingSystem >= CLIENTOS_OTCLIENT_LINUX) {
+	if (isOTCv8 || operatingSystem >= CLIENTOS_OTCLIENT_LINUX) {
 		if (isOTCv8) {
 			sendOTCv8Features();
 		}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -370,8 +370,10 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		isOTCv8 = msg.get<uint16_t>() != 0;
 	}
 
-	if (isOTCv8) {
-		sendOTCv8Features();
+	if (operatingSystem >= CLIENTOS_OTCLIENT_LINUX) {
+		if (isOTCv8) {
+			sendOTCv8Features();
+		}
 		NetworkMessage opcodeMessage;
 		opcodeMessage.addByte(0x32);
 		opcodeMessage.addByte(0x00);


### PR DESCRIPTION
a person asked me for help to fix this.


# Mehah:
```lua
ERROR: Unable to send extended opcode 1, extended opcodes are not enabled
ERROR: Unable to send extended opcode 201, extended opcodes are not enabled
```

![image](https://github.com/user-attachments/assets/3c261b12-2a99-4df4-a485-a5fdb5852c68)


# v8:
![image](https://github.com/user-attachments/assets/fed3d0fc-03fc-4b67-8d40-6529e5d3766b)


# Cipsoft:
![image](https://github.com/user-attachments/assets/d053e638-42e5-4eae-b5d7-1272983112e1)
