### PR TITLE
Fix skill and magic level percent overflow in protocol

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -345,7 +345,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	}
 
 	player->manaSpent = manaSpent;
-	player->magLevelPercent = Player::getBasisPointLevel(player->manaSpent, nextManaCount);
+	player->magLevelPercent = Player::getBasisPointLevel(player->manaSpent, nextManaCount) / 100;
 
 	player->health = result->getNumber<int32_t>("health");
 	player->healthMax = result->getNumber<int32_t>("healthmax");
@@ -415,7 +415,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 		player->skills[i].level = skillLevel;
 		player->skills[i].tries = skillTries;
-		player->skills[i].percent = Player::getBasisPointLevel(skillTries, nextSkillTries);
+		player->skills[i].percent = Player::getBasisPointLevel(skillTries, nextSkillTries) / 100;
 	}
 
 	if ((result = db.storeQuery(

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -452,15 +452,15 @@ void Player::addSkillAdvance(skills_t skill, uint64_t count, bool artificial /*=
 
 	skills[skill].tries += count;
 
-	uint32_t newPercent;
+	uint8_t newPercent;
 	if (nextReqTries > currReqTries) {
-		newPercent = Player::getBasisPointLevel(skills[skill].tries, nextReqTries);
+		newPercent = Player::getBasisPointLevel(skills[skill].tries, nextReqTries) / 100;
 	} else {
 		newPercent = 0;
 	}
 
 	if (skills[skill].percent != newPercent) {
-		skills[skill].percent = static_cast<uint8_t>(newPercent);
+		skills[skill].percent = newPercent;
 		sendUpdateSkills = true;
 	}
 
@@ -490,7 +490,7 @@ void Player::removeSkillTries(skills_t skill, uint64_t count, bool notify /* = f
 
 	skills[skill].tries = std::max<int32_t>(0, skills[skill].tries - count);
 	skills[skill].percent =
-	    Player::getBasisPointLevel(skills[skill].tries, vocation->getReqSkillTries(skill, skills[skill].level));
+	    Player::getBasisPointLevel(skills[skill].tries, vocation->getReqSkillTries(skill, skills[skill].level)) / 100;
 
 	if (notify) {
 		bool sendUpdateSkills = false;
@@ -1488,7 +1488,7 @@ void Player::addManaSpent(uint64_t amount, bool artificial /*= false*/)
 
 	uint8_t oldPercent = magLevelPercent;
 	if (nextReqMana > currReqMana) {
-		magLevelPercent = Player::getBasisPointLevel(manaSpent, nextReqMana);
+		magLevelPercent = Player::getBasisPointLevel(manaSpent, nextReqMana) / 100;
 	} else {
 		magLevelPercent = 0;
 	}
@@ -1521,7 +1521,7 @@ void Player::removeManaSpent(uint64_t amount, bool notify /* = false*/)
 
 	uint64_t nextReqMana = vocation->getReqMana(magLevel + 1);
 	if (nextReqMana > vocation->getReqMana(magLevel)) {
-		magLevelPercent = Player::getBasisPointLevel(manaSpent, nextReqMana);
+		magLevelPercent = Player::getBasisPointLevel(manaSpent, nextReqMana) / 100;
 	} else {
 		magLevelPercent = 0;
 	}
@@ -4213,7 +4213,7 @@ void Player::dismount()
 
         uint8_t newPercent;
         if (nextReqMana > currReqMana) {
-            newPercent = Player::getBasisPointLevel(manaSpent, nextReqMana);
+            newPercent = Player::getBasisPointLevel(manaSpent, nextReqMana) / 100;
             newPercentToNextLevel = static_cast<long double>(manaSpent * 100) / nextReqMana;
         } else {
             newPercent = 0;
@@ -4267,7 +4267,7 @@ skills[skill].level));
 
         uint8_t newPercent;
         if (nextReqTries > currReqTries) {
-            newPercent = Player::getBasisPointLevel(skills[skill].tries, nextReqTries);
+            newPercent = Player::getBasisPointLevel(skills[skill].tries, nextReqTries) / 100;
             newPercentToNextLevel = static_cast<long double>(skills[skill].tries * 100) / nextReqTries;
         } else {
             newPercent = 0;

--- a/src/player.h
+++ b/src/player.h
@@ -73,7 +73,7 @@ struct Skill
 {
 	uint64_t tries = 0;
 	uint16_t level = MINIMUM_SKILL_LEVEL;
-	uint16_t percent = 0;
+	uint8_t percent = 0;
 };
 
 using MuteCountMap = std::map<uint32_t, uint32_t>;
@@ -261,7 +261,7 @@ public:
 	}
 	int32_t getExperienceRate(ExperienceRateType type) const { return experienceRate[static_cast<size_t>(type)]; }
 	uint32_t getBaseMagicLevel() const { return magLevel; }
-	uint16_t getMagicLevelPercent() const { return magLevelPercent; }
+	uint8_t getMagicLevelPercent() const { return magLevelPercent; }
 	uint8_t getSoul() const { return soul; }
 	bool isAccessPlayer() const { return group->access; }
 	bool isPremium() const;
@@ -443,7 +443,7 @@ public:
 		return static_cast<uint16_t>(std::max<int32_t>(0, specialMagicLevelSkill[combatTypeToIndex(type)]));
 	}
 	uint16_t getBaseSkill(uint8_t skill) const { return skills[skill].level; }
-	uint16_t getSkillPercent(uint8_t skill) const { return skills[skill].percent; }
+	uint8_t getSkillPercent(uint8_t skill) const { return skills[skill].percent; }
 	uint64_t getSkillTries(uint8_t skill) const { return skills[skill].tries; }
 
 	bool getAddAttackSkill() const { return addAttackSkillPoint; }
@@ -1117,7 +1117,7 @@ private:
 	uint8_t soul = 0;
 	std::bitset<PLAYER_MAX_BLESSINGS + 1> blessings;
 	uint8_t levelPercent = 0;
-	uint16_t magLevelPercent = 0;
+	uint8_t magLevelPercent = 0;
 
 	PlayerSex_t sex = PLAYERSEX_FEMALE;
 	OperatingSystem_t operatingSystem = CLIENTOS_NONE;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2479,7 +2479,7 @@ void ProtocolGame::AddPlayerStats(NetworkMessage& msg)
 		msg.addByte(
 		    static_cast<uint8_t>(std::min<uint32_t>(player->getBaseMagicLevel(), std::numeric_limits<uint8_t>::max())));
 	}
-	msg.addByte(static_cast<uint8_t>(player->getMagicLevelPercent()));
+	msg.addByte(player->getMagicLevelPercent());
 
 	msg.addByte(player->getSoul());
 
@@ -2509,13 +2509,13 @@ void ProtocolGame::AddPlayerSkills(NetworkMessage& msg)
 		for (uint8_t i = SKILL_FIRST; i <= SKILL_LAST; ++i) {
 			msg.addByte(
 			    std::min<uint8_t>(static_cast<uint8_t>(player->getSkillLevel(i)), std::numeric_limits<uint8_t>::max()));
-			msg.addByte(static_cast<uint8_t>(player->getSkillPercent(i)));
+			msg.addByte(player->getSkillPercent(i));
 		}
 	} else {
 		for (uint8_t i = SKILL_FIRST; i <= SKILL_LAST; ++i) {
 			msg.add<uint16_t>(std::min<uint16_t>(player->getSkillLevel(i), std::numeric_limits<uint16_t>::max()));
 			msg.add<uint16_t>(player->getBaseSkill(i));
-			msg.addByte(static_cast<uint8_t>(player->getSkillPercent(i)));
+			msg.addByte(player->getSkillPercent(i));
 		}
 
 		for (uint8_t i = SPECIALSKILL_FIRST; i <= SPECIALSKILL_LAST; ++i) {


### PR DESCRIPTION
## Summary
- `getBasisPointLevel()` returns values in basis points (0–10000), but `magLevelPercent` and `skills[].percent` were storing these raw values without dividing by 100
- When sent to the 8.60 client as `uint8_t`, values above 255 silently overflow, causing incorrect percentages in the skill bar — especially noticeable at higher levels
- Changed `magLevelPercent` and `Skill::percent` types from `uint16_t` to `uint8_t` and added `/ 100` to all `getBasisPointLevel()` assignments, matching the existing behavior of `levelPercent`

## Test plan
- [ ] Create or use a high-level character where skill/magic level progress would produce basis point values > 255
- [ ] Open the skill bar in client 8.60 and verify all percentages display correctly (0–100%)
- [ ] Verify level percent still works correctly
- [ ] Test with OTCv8 client as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)