### PR TITLE
Add Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,40 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    # Solo corre si:
+    # - Es un PR abierto/actualizado por el OWNER del repo, O
+    # - Es un comentario que menciona @claude hecho por el OWNER
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.login == github.repository_owner) ||
+      ((github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
+       github.event.comment.user.login == github.repository_owner &&
+       contains(github.event.comment.body, '@claude'))
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code-review.yml` que dispara en PRs y comentarios `@claude` hechos por el owner del repo.
- Usa la action oficial `anthropics/claude-code-action@v1` con el secret `CLAUDE_CODE_OAUTH_TOKEN`.

## Test plan
- [ ] Verificar que el workflow se dispara al abrir este PR.
- [ ] Comentar `@claude` en este PR y confirmar que responde.
- [ ] Confirmar que comentarios de no-owners son ignorados (gracias al filtro `if`).